### PR TITLE
handbook: add required domaintools python module

### DIFF
--- a/handbook/ubuntu-16.04/Dockerfile
+++ b/handbook/ubuntu-16.04/Dockerfile
@@ -1,14 +1,16 @@
 FROM ubuntu:16.04
 MAINTAINER Rasmus Villemoes <ravi@prevas.dk>
 
-RUN apt-get -y update
-RUN apt-get install -y        \
+RUN apt-get update &&         \
+    apt-get install -y        \
     apt-utils sudo            \
     bash-completion git make  \
     python-sphinx             \
-    sphinx-rtd-theme-common
+    sphinx-rtd-theme-common   \
+    python-pip
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
+RUN pip install sphinxcontrib-domaintools
 
 # TBD: Figure out the necessary packages to allow "make latexpdf" to
 # build a pdf version. Probably at least these:


### PR DESCRIPTION
I've started defining a custom "domain" allowing us to define various
syntactic elements, which is nice both for syntax highlighting, but also
for creating an index of e.g. common variables. But this requires a few
python modules provided via pip.

This also combines the apt-get update with the apt-get install commands,
which is apparently necessary and a common
gotcha (https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).